### PR TITLE
Fixed small typo in the get_b2_resource function parameters.

### DIFF
--- a/sample.py
+++ b/sample.py
@@ -118,8 +118,8 @@ def get_b2_client(endpoint, keyID, applicationKey):
 def get_b2_resource(endpoint, key_id, application_key):
     b2 = boto3.resource(service_name='s3',
                         endpoint_url=endpoint,                # Backblaze endpoint
-                        aws_access_key_id=keyID,              # Backblaze keyID
-                        aws_secret_access_key=applicationKey, # Backblaze applicationKey
+                        aws_access_key_id=key_id,              # Backblaze keyID
+                        aws_secret_access_key=application_key, # Backblaze applicationKey
                         config = Config(
                             signature_version='s3v4',
                     ))


### PR DESCRIPTION
The `boto3.resource()` call was using incorrect parameters for  `aws_access_key_id` and `aws_secret_access_key`.